### PR TITLE
Make vault accessible on demand by builds

### DIFF
--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -6,7 +6,7 @@ set -e
 #VAULT_SECRET_ID
 
 # store secret id for future logins
-echo "$VAULT_SECRET_ID" > ~/.vault-secret
+echo "$VAULT_SECRET_ID" > ~/.vault-secret-id
 
 # login
 export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"

--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -5,6 +5,9 @@ set -e
 #VAULT_ROLE_ID
 #VAULT_SECRET_ID
 
+# store secret id for future logins
+sudo echo "export VAULT_SECRET_ID=$VAULT_SECRET_ID" > /etc/profile.d/vault-secret-id.sh
+
 # login
 export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"
 

--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -6,7 +6,7 @@ set -e
 #VAULT_SECRET_ID
 
 # store secret id for future logins
-sudo echo "export VAULT_SECRET_ID=$VAULT_SECRET_ID" > ~/.vault-secret
+echo "$VAULT_SECRET_ID" > ~/.vault-secret
 
 # login
 export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"

--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -6,7 +6,7 @@ set -e
 #VAULT_SECRET_ID
 
 # store secret id for future logins
-sudo echo "export VAULT_SECRET_ID=$VAULT_SECRET_ID" > /etc/profile.d/vault-secret-id.sh
+sudo echo "export VAULT_SECRET_ID=$VAULT_SECRET_ID" > ~/.vault-secret
 
 # login
 export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"

--- a/salt/containers/config/usr-local-bin-vault.sh
+++ b/salt/containers/config/usr-local-bin-vault.sh
@@ -5,6 +5,7 @@ set -e
 #VAULT_ROLE_ID
 #VAULT_SECRET_ID
 
+export VAULT_SECRET_ID=$(cat ~/.vault-secret-id)
 export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"
 
 vault $@

--- a/salt/containers/config/usr-local-bin-vault.sh
+++ b/salt/containers/config/usr-local-bin-vault.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+# needs the following environment variables:
+#VAULT_ADDR
+#VAULT_ROLE_ID
+#VAULT_SECRET_ID
+
+export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"
+
+vault $@

--- a/salt/containers/init.sls
+++ b/salt/containers/init.sls
@@ -5,8 +5,14 @@ credentials-environment-variables:
             export VAULT_ADDR={{ pillar.containers.vault.addr }}
             export VAULT_ROLE_ID={{ pillar.containers.vault.role_id }}
 
-credentials-setup:
+credentials-initial-setup:
     file.managed:
         - name: /usr/local/bin/setup-secrets.sh
         - source: salt://containers/config/usr-local-bin-setup-secrets.sh
+        - mode: 755
+
+credentials-on-demand:
+    file.managed:
+        - name: /usr/local/bin/vault.sh
+        - source: salt://containers/config/usr-local-bin-vault.sh
         - mode: 755


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4467

~95ae571d-dc22-2956-6ceb-1082d10813ee~ role id of Jenkins

After this, I can simply run:
```
vault.sh read -field credentials secret/containers/data-pipeline/gcp 
```

to get the JSON credentials for GCP.