### PR TITLE
Make SSH key Vault path robust to different secret engines/versions

### DIFF
--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -13,5 +13,5 @@ export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAUL
 
 # SSH credentials
 rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
-vault kv get -format=json secret/containers/ssh | jq -r .data.data.private_key > ~/.ssh/id_rsa
+vault kv get -field=private_key secret/containers/ssh > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa

--- a/salt/containers/config/usr-local-bin-setup-secrets.sh
+++ b/salt/containers/config/usr-local-bin-setup-secrets.sh
@@ -10,5 +10,5 @@ export VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="$VAUL
 
 # SSH credentials
 rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
-vault kv get -format=json secret/containers/ssh | jq -r .data.private_key > ~/.ssh/id_rsa
+vault kv get -format=json secret/containers/ssh | jq -r .data.data.private_key > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
Due to the use of the versioned key value secret store