### PR TITLE
adds java to list of packages to install

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -2,6 +2,7 @@ base:
     '*':
         - elife
         - elife.external-volume
+        - elife.java8
         - elife.jenkins-scripts
         - elife.docker
         - elife.docker-push


### PR DESCRIPTION
this is so the jenkins agent .jar file can be executed.

not sure how it's managed to run up to this point, but I'm *guessing* that the instance the previous AMI was created from was tweaked outside of the formula. It also may have had java removed during the recent oracle java 7 purge?